### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ testnet.json
 /build/bin/
 # IdeaIDE  (JetBrains stuff)
 .idea/
+www/node_modules/
+www/bower_components/
+www/package-lock.json


### PR DESCRIPTION
update .gitignore is used to eliminate local environment differences when different developers compile the web part.